### PR TITLE
fix(canonical-bridge-server): Remove failed jobs so fixed-jobId crons…

### DIFF
--- a/apps/canonical-bridge-server/src/app.module.ts
+++ b/apps/canonical-bridge-server/src/app.module.ts
@@ -40,7 +40,11 @@ import { BridgeModule } from '@/module/bridge/bridge.module';
       defaultJobOptions: {
         attempts: 3,
         removeOnComplete: 100,
-        removeOnFail: 10,
+        // All jobs are enqueued with fixed jobIds, and BullMQ silently drops an add()
+        // whose jobId still has a job record in ANY state. A retained failed record
+        // therefore blocks that job from ever being enqueued again until the next
+        // restart, so failed records must be removed immediately.
+        removeOnFail: true,
       },
     }),
   ],


### PR DESCRIPTION
… can re-enqueue

All BullMQ jobs are enqueued with fixed jobIds, and BullMQ silently ignores an add() whose jobId still has a job record in any state. With removeOnFail: 10, a single failure (e.g. a job stalled by a pod restart) left a failed record that blocked every subsequent cron add() for that jobId until the next app restart. This wedged cacheCmcConfigV2 on 2026-08-01: the cmc:config_v2 cache key expired after its 1-day TTL and /api/token/v2/cmc served an empty response for over a day.

Setting removeOnFail: true deletes the failed record immediately, so the next cron tick re-enqueues the job as normal.

## Description

<!--- Describe your changes in detail -->

## Issue ticket number and link

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
